### PR TITLE
7장, 9장 예제 코드 오류 수정

### DIFF
--- a/7장/7.1.6-2.tsx
+++ b/7장/7.1.6-2.tsx
@@ -5,7 +5,7 @@ const ListPage: React.FC = () => {
   useEffect(() => {
     // 예시를 위한 API 호출과 then 구문
     fetchList(filter).then(({ items }) => {
-      setCartCount(items.length);
+      setTotalItemCount(items.length);
       setItems(items);
     });
   }, []);

--- a/9장/9.1.1-2.ts
+++ b/9장/9.1.1-2.ts
@@ -20,7 +20,7 @@ const MemberList = () => {
       ...memberList,
       {
         name: "DokgoBaedal",
-        age: 11,
+        agee: 11,
       },
     ]);
   };


### PR DESCRIPTION
안녕하세요 😀
본 레포지토리의 원문 도서 '우아한 타입스크립트 with 리액트' 로 프론트 스터디 진행 중에 예제 코드에 오류가 있는 것 같아서 해당 풀리퀘스트를 올리게 되었습니다.

아래는 두 가지 수정 사항입니다.
1.
```tsx
// 7장/7.1.6-2.tsx

const ListPage: React.FC = () => {
  const [totalItemCount, setTotalItemCount] = useState(0);
  const [items, setItems] = useState<ListItem[]>([]);

  useEffect(() => {
    // 예시를 위한 API 호출과 then 구문
    fetchList(filter).then(({ items }) => {
      setTotalItemCount(items.length); // <- 수정한 부분 (수정 전: setCartCount(items.length);)
      setItems(items);
    });
  }, []);

  return (
    <div>
      <Chip label={totalItemCount} />
      <Table items={items} />
    </div>
  );
};
```
useEffect 훅을 내부의 fetchList 부분에서 `setTotalItemCount`로 추정되는 부분에 `setCartCount`로 작성되어 있어 수정해 보았습니다.

2.
```tsx
// 9장/9.1.1-2.ts

import { useState } from "react";

const MemberList = () => {
  const [memberList, setMemberList] = useState([
    {
      name: "KingBaedal",
      age: 10,
      },
    {
      name: "MayBaedal",
      age: 9,
    },
  ]);
  
  // 🚨 addMember 함수를 호출하면 sumAge는 NaN이 된다
  const sumAge = memberList.reduce((sum, member) => sum + member.age, 0);
  
  const addMember = () => {
    setMemberList([
      ...memberList,
      {
        name: "DokgoBaedal",
        agee: 11, // <- 수정한 부분 (수정 전: age: 11,)
      },
    ]);
  };
};
```
`age` 속성을 `agee` 로 잘못 입력하는 경우의 타입 에러를 잡는 예제 코드입니다. 해당 부분에 `agee`가 있어야 할 부분에 올바른 동작을 하는 `age`로 작성되어 있어 수정해 보았습니다.

본 도서로 타입스크립트 공부하며 많이 도움받고 있습니다. 사소한 오탈자를 발견하여 수정 사항을 업로드하게 되었습니다 :)