### PR TITLE
fix: 7.3.1-3 예제코드 오류 수정

### DIFF
--- a/7장/7.3.1-3.ts
+++ b/7장/7.3.1-3.ts
@@ -5,7 +5,8 @@ const onClickDeleteHistoryButton = async (id: string) => {
     alert("주문 내역이 삭제되었습니다.");
   } catch (error: unknown) {
     if (isServerError(e) && e.response && e.response.data.errorMessage) {
-      // 서버 에러일 때의 처리임을 명시적으로 알 수 있다 setErrorMessage(e.response.data.errorMessage);
+      // 서버 에러일 때의 처리임을 명시적으로 알 수 있다 
+      setErrorMessage(e.response.data.errorMessage);
       return;
     }
     setErrorMessage("일시적인 에러가 발생했습니다. 잠시 후 다시 시도해주세요");


### PR DESCRIPTION
안녕하세요. <우아한 타입스크립트 with 리액트>를 읽다가 도서와 예제 코드가 다른 부분이 있어 수정하였습니다.

## 수정사항
주석 처리된 코드를 개행 처리했습니다.
결론적으로 책의 내용과 동일한 코드가 됐습니다.

### 수정 전
```ts
// 서버 에러일 때의 처리임을 명시적으로 알 수 있다 setErrorMessage(e.response.data.errorMessage);
```

### 수정 후
```ts
// 서버 에러일 때의 처리임을 명시적으로 알 수 있다 
setErrorMessage(e.response.data.errorMessage);
```
