### PR TITLE
5.4장 예제의 typeof keyof 를 keyof typeof 로 수정

### DIFF
--- a/5장/5.4.1-4.tsx
+++ b/5장/5.4.1-4.tsx
@@ -26,9 +26,9 @@ const theme = {
   },
 };
 
-type ColorType = typeof keyof theme.colors;
-type BackgroundColorType = typeof keyof theme.backgroundColor;
-type FontSizeType = typeof keyof theme.fontSize;
+type ColorType = keyof typeof theme.colors;
+type BackgroundColorType = keyof typeof theme.backgroundColor;
+type FontSizeType = keyof typeof theme.fontSize;
 
 interface Props {
   color?: ColorType;


### PR DESCRIPTION
좋은 책을 발간해주셔서 저희 팀에서 재밌게 스터디를 하고 있습니다. 대단히 감사합니다.

객체에서 타입을 추출하고, 타입에서 key 를 추출하려는 의도여서 typeof keyof 가 아닌 keyof typeof 가 맞을 것 같습니다. 실제 이 코드를 typescript playground에 복붙하면 keyof 에서 `cannot find name keyof` 경고가 나타납니다. typeof 오른쪽에는 정의된 변수가 나와야 하는데, keyof 라는 키워드가 있다보니 그런 것 아닐까 싶은데요. 한 번 확인 부탁드립니다.