### PR TITLE
fix: 5.4.1-4 예제 오류 수정

### DIFF
--- a/5장/5.4.1-4.tsx
+++ b/5장/5.4.1-4.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import React, { FC } from "react";
 import styled from "styled-components";
 
 const colors = {
@@ -13,7 +13,7 @@ const theme = {
     default: colors.gray,
     ...colors
   },
-  backgroundColor: {
+  backgroundColors: {
     default: colors.white,
     gray: colors.gray,
     mint: colors.mint,
@@ -27,13 +27,14 @@ const theme = {
 };
 
 type ColorType = keyof typeof theme.colors;
-type BackgroundColorType = keyof typeof theme.backgroundColor;
+type BackgroundColorType = keyof typeof theme.backgroundColors;
 type FontSizeType = keyof typeof theme.fontSize;
 
 interface Props {
   color?: ColorType;
   backgroundColor?: BackgroundColorType;
   fontSize?: FontSizeType;
+  children?: React.ReactNode;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
 }
 
@@ -50,8 +51,8 @@ const Button: FC<Props> = ({ fontSize, backgroundColor, color, children }) => {
 };
 
 const ButtonWrap = styled.button<Omit<Props, "onClick">>`
-  color: ${({ color }) => theme.color[color ?? "default"]};
+  color: ${({ color }) => theme.colors[color ?? "default"]};
   background-color: ${({ backgroundColor }) =>
-    theme.bgColor[backgroundColor ?? "default"]};
+    theme.backgroundColors[backgroundColor ?? "default"]};
   font-size: ${({ fontSize }) => theme.fontSize[fontSize ?? "default"]};
 `;


### PR DESCRIPTION
## 개요

[5.4장 예제의 typeof keyof 를 keyof typeof 로 수정](https://github.com/woowa-typescript/woowahan-typescript-with-react-example-code/pull/12) PR 에서 요청주신 수정사항을 확인하다 추가 오류를 발견했습니다. 이를 수정합니다.

## 수정 사항

- theme 객체 접근자의 필드명이 잘못된 것을 수정
- backgroundColor -> backgroundColors 로 다른 필드 colors와 컨벤션을 맞춤
- 그 외 import, props 에서 누락된 부분 추가