### PR TITLE
fix: 3.2.4 2 예제 코드 오류 수정

### DIFF
--- a/3장/3.2.4-2.ts
+++ b/3장/3.2.4-2.ts
@@ -1,9 +1,8 @@
 const PromotionList = [
   { type: "product", name: "chicken" },
   { type: "product", name: "pizza" },
-  { type: "card", name: "chee-up" },
+  { type: "card", name: "cheer-up" },
 ];
 
-type ElementOf<T> = (typeof T)[number];
 // type PromotionItemType = { type: string; name: string }
-type PromotionItemType = ElementOf<PromotionList>;
+type PromotionItemType = typeof PromotionList[number];

--- a/3장/3.2.4-2.ts
+++ b/3장/3.2.4-2.ts
@@ -1,8 +1,9 @@
 const PromotionList = [
   { type: "product", name: "chicken" },
   { type: "product", name: "pizza" },
-  { type: "card", name: "cheer-up" },
+  { type: "card", name: "chee-up" },
 ];
 
+type ElementOf<T> = (typeof T)[number];
 // type PromotionItemType = { type: string; name: string }
-type PromotionItemType = typeof PromotionList[number];
+type PromotionItemType = ElementOf<PromotionList>;

--- a/9장/9.2.1-2.jsx
+++ b/9장/9.2.1-2.jsx
@@ -4,9 +4,9 @@ const MyComponent = () => {
   return (
     <div>
       <h1>{value}</h1>
-      <input onChange= {onChange} value= {text} />
+      <input onChange= {onChange} value= {value} />
     </div>
   );
 };
 
-export default App;
+export default MyComponent;


### PR DESCRIPTION
안녕하세요, 책의 예제를 보고 오류를 발견해서, 수정 후 PR 드립니다.

# 수정사항
인덱스드 엑세스 타입 예제 코드에 수정사항이 있습니다.
(1) PromotionList 객체 배열의 마지막 요소에 오타가 있어 변경: chee-up -> cheer-up
     ※ 출판 도서에서는 수정 되어 있음. 대신 객체에 쉼표가 없음...
(2) 인덱스드 엑세스 타입 부분에 에러가 발생해서 수정: (아래 참조)

## 수정 전
```typescript
const PromotionList = [
  { type: "product", name: "chicken" },
  { type: "product", name: "pizza" },
  { type: "card", name: "chee-up" }, // 오타
];

type ElementOf<T> = (typeof T)[number]; // Error: 'T' only refers to a type, but is being used as a value here.
// type PromotionItemType = { type: string; name: string }
type PromotionItemType = ElementOf<PromotionList>; // Error: 'PromotionList' refers to a value, but is being used as a type here.
```
## 수정 후
```typescript
const PromotionList = [
  { type: "product", name: "chicken" },
  { type: "product", name: "pizza" },
  { type: "card", name: "cheer-up" },
];

// type PromotionItemType = { type: string; name: string }
type PromotionItemType = typeof PromotionList[number];
```