### PR TITLE
fix: 7.4.4-2 예제코드 오류 수정

### DIFF
--- a/7장/7.4.4-2.ts
+++ b/7장/7.4.4-2.ts
@@ -12,12 +12,12 @@ export const lazyData = (
 
 export const fetchOrderListMock = ({
   status = 200,
-  time = 100,
+  delay = 100,
   use = true,
 }: MockResult) =>
   use &&
   mock
     .onGet(/\/order\/list/)
     .reply(() =>
-      lazyData(status, fetchOrderListSuccessResponse, undefined, time)
+      lazyData(status, fetchOrderListSuccessResponse, undefined, delay)
     );


### PR DESCRIPTION
안녕하세요. 도서에 나온 코드를 확인하다가, 예제 코드가 다른 부분이 있어 수정하였습니다.

## 수정사항

앞선 코드에서 `MockResult`의 타입이 다음과 같이 정의되어 있었는데, `fetchOrderListMock` 메서드의 인자로 받아오는 매개변수의 타입이 잘못되어 있어 수정하였습니다.

```typescript
interface MockResult {
  status?: number;
  delay?: number;
  use?: boolean;
}
```

### 수정 전

```typescript
export const fetchOrderListMock = ({
  status = 200,
  time = 100, // 🚨
  use = true,
}: MockResult) =>
  use &&
  mock
    .onGet(/\/order\/list/)
    .reply(() =>
      lazyData(status, fetchOrderListSuccessResponse, undefined, time) // 🚨
    );
```

### 수정 후

```typescript
export const fetchOrderListMock = ({
  status = 200,
  delay = 100,
  use = true,
}: MockResult) =>
  use &&
  mock
    .onGet(/\/order\/list/)
    .reply(() =>
      lazyData(status, fetchOrderListSuccessResponse, undefined, delay)
    );
```