### PR TITLE
fix: 3.2.4-2 예제코드 오류 수정

### DIFF
--- a/3장/3.2.4-2.ts
+++ b/3장/3.2.4-2.ts
@@ -4,6 +4,7 @@ const PromotionList = [
   { type: "card", name: "chee-up" },
 ];
 
-type ElementOf<T> = (typeof T)[number];
+type ElementOf<T extends readonly any[]> = T[number];
+
 // type PromotionItemType = { type: string; name: string }
-type PromotionItemType = ElementOf<PromotionList>;
+type PromotionItemType = ElementOf<typeof PromotionList>;


### PR DESCRIPTION
안녕하세요, 책의 예제를 보고 오류를 발견해서 수정 요청 드립니다.

## 수정사항
책 101 ~102페이지 4.인덱스드 엑세스 타입(Indexed Access Types) 예제 코드에서,
**제네릭을 타입이 아닌 값으로 사용**하고 있어 수정이 필요하다고 생각됩니다.

### 수정 전
```ts
const PromotionList = [
  { type: "product", name: "chicken" },
  { type: "product", name: "pizza" },
  { type: "card", name: "cheer-up" }, 
];

type ElementOf<T> = (typeof T)[number];

// type PromotionItemType = { type: string; name: string }
type PromotionItemType = ElementOf<PromotionList>;
```
### 수정 후
```ts
const PromotionList = [
  { type: "product", name: "chicken" },
  { type: "product", name: "pizza" },
  { type: "card", name: "chee-up" },
];

type ElementOf<T extends readonly any[]> = T[number];

// type PromotionItemType = { type: string; name: string }
type PromotionItemType = ElementOf<typeof PromotionList>;
```