### PR TITLE
fix: 5.3.2-4 예제코드 오류 수정

### DIFF
--- a/5장/5.3.2-4.ts
+++ b/5장/5.3.2-4.ts
@@ -1,4 +1,4 @@
 type PayMethod =
   | { account: string; card?: undefined; payMoney?: undefined }
-  | { account: undefined; card?: string; payMoney?: undefined }
-  | { account: undefined; card?: undefined; payMoney?: string };
+  | { account?: undefined; card: string; payMoney?: undefined }
+  | { account?: undefined; card?: undefined; payMoney: string };


### PR DESCRIPTION
안녕하세요, 책의 예제를 보고 오류를 발견해서 수정 요청 드립니다.

## 수정사항
책 168페이지 PayMethod 타입 예제 코드에서, account, card, payMoney속성중 하나만을 필수로 받기위해 하나의 속성이 들어왔을 때 다른 타입을 옵셔널한 undefined값으로 지정한다고 적힌 설명과 아래의 예제 코드가 맞지 않아 수정했습니다.

### 수정 후
type PayMethod =
  | { **account: string;** card?: undefined; payMoney?: undefined }
  | { account?: undefined; **card: string;** payMoney?: undefined }
  | { account?: undefined; card?: undefined; **payMoney: string** };

 
책 잘 읽고 있습니다! typescript를 이해하는데 많은 도움이 되고 있습니다. 감사합니다.